### PR TITLE
Implement tls subscription create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 
 .envrc
+.idea

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To add TLS to a domain your pricing plan must include a TLS domain and the domai
 The process involves creating the TLS Domain, verifying ownership of your domain, and checking the verification status of your domain. Usage:
 
 ```
-heroku fastly:tls DOMAIN [VERIFICATION_TYPE]
+heroku fastly:tls DOMAIN --app [HEROKU_APP_NAME]
 ```
 
 To add TLS/SSL to a custom domain:
@@ -27,19 +27,17 @@ To add TLS/SSL to a custom domain:
 ```
 heroku fastly:tls www.example.org --app my-fast-app
 ```
-Create a DNS TXT record with the verification string output from this command.
+The output of add TLS/SSL command will provide the required DNS record values that need to be 
+add to your DNS provider configuration.  These include the acme challenge as well as A/CNAME record entries.
 
 ```
-heroku fastly:verify start www.example.org --app my-fast-app
+heroku fastly:verify www.example.org
 ```
-Verfies ownership of the domain via the DNS TXT record added from output of the previous command.
-
+Verifies the state of the add TLS/SSL request.
 
 ```
-heroku fastly:verify status www.example.org --app my-fast-app
+heroku fastly:verify www.example.org
 ```
-Checks the status of the verification process. If complete, a new CNAME will be output that you can update to after the new certificate propagates to all caches.
-
 
 To remove TLS/SSL from a custom domain, include the the `-d` flag:
 
@@ -99,7 +97,7 @@ heroku-fastly 1.0.7 (link) /Users/your-path/heroku-fastly
  ▸    $ heroku fastly:verify start DOMAIN —app APP
  ```
 
-* Test `verify` command. Run `heroku fastly:verify start www.example.org --app my-fast-app`, will return something like: 
+* Test `verify` command. Run `heroku fastly:verify www.example.org`, will return something like: 
 
 ```
  ▸    Valid approval domains: example.org, www.example.org

--- a/README.md
+++ b/README.md
@@ -30,17 +30,12 @@ heroku fastly:tls www.example.org --app my-fast-app
 The output of add TLS/SSL command will provide the required DNS record values that need to be 
 add to your DNS provider configuration.  These include the acme challenge as well as A/CNAME record entries.
 
-```
-heroku fastly:verify www.example.org
-```
 Verifies the state of the add TLS/SSL request.
-
 ```
 heroku fastly:verify www.example.org
 ```
 
 To remove TLS/SSL from a custom domain, include the the `-d` flag:
-
 ```
 heroku fastly:tls -d www.example.org --app my-fast-app
 ```
@@ -89,19 +84,24 @@ heroku-fastly 1.0.7 (link) /Users/your-path/heroku-fastly
 
 ```
 === Domain www.example.org has been queued for TLS certificate addition. This may take a few minutes.
- ▸    In the mean time, start the domain verification process by creating a DNS TXT record containing the following content:
- ▸
- ▸
- ▸    Once you have added this TXT record you can start the verification process by running:
- ▸
- ▸    $ heroku fastly:verify start DOMAIN —app APP
+
+=== To start the domain verification process create a DNS CNAME record.
+
+CNAME _acme-challenge.www.example.org lja6px7qnjrx5dgqd7.fastly-validations.com
+
+=== Alongside the initial verification record either the following CNAME and/or A records are required.
+
+CNAME www.example.org j.sni.global.fastly.net
+
+A www.example.org 151.101.2.132, 151.101.66.132, 151.101.130.132, 151.101.194.132
  ```
 
 * Test `verify` command. Run `heroku fastly:verify www.example.org`, will return something like: 
 
 ```
- ▸    Valid approval domains: example.org, www.example.org
-Type the approval domain to use (or ENTER if only 1): : ^C
+ (node:55920) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
+ === Domain www.example.org TLS subscription state: pending
+ The issuing of a certificate may take up to 30 minutes.  In the mean time please confirm your DNS records are configured with your DNS provider for fastlydev.thinkcheesy.com
 ```
 
 * Test `purge` command. Run `heroku fastly:purge --all --app my-fast-app`, will return something like:

--- a/commands/purge.js
+++ b/commands/purge.js
@@ -22,7 +22,7 @@ module.exports = {
       return hk.error('You must specify `--all` or a key to purge with.')
     }
 
-    return co(function*() {
+    return co(function* () {
       let config = yield heroku.get(`/apps/${context.app}/config-vars`)
       const fastly = require('fastly')(config.FASTLY_API_KEY)
 

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -9,7 +9,13 @@ module.exports = {
   topic: 'fastly',
   command: 'tls',
   description: 'Add/Remove Fastly TLS to DOMAIN',
-  help: 'TODO - Update documentation to reflect the use of tls/subscriptions',
+  help: 'DOMAIN will be added to a Fastly Heroku SAN SSL certificate. \n\n\
+Requirements: \n\
+ - The Fastly Service must have DOMAIN configured in the active version \n\
+ - Heroku pricing plan must include TLS Domain(s) \n\
+ - Wildcard domains are not allowed \n\n\
+Usage: \n\
+  heroku fastly:tls www.example.org --app my-fast-app\n ',
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'domain', description: 'The domain for TLS configure' }],

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -4,6 +4,7 @@ const request = require('request')
 const co = require('co')
 
 module.exports = {
+
   topic: 'fastly',
   command: 'tls',
   description: 'Add/Remove Fastly TLS to DOMAIN',
@@ -13,117 +14,133 @@ module.exports = {
   args: [{ name: 'domain', description: 'The domain for TLS configure' }],
   flags: [
     { name: 'delete', char: 'd', description: 'Remove TLS from DOMAIN', hasValue: false },
-    {
-      name: 'api_key',
-      char: 'k',
-      description: 'Override FASTLY_API_KEY config var',
-      hasValue: true,
-    },
     { name: 'api_uri', char: 'u', description: 'Override Fastly API URI', hasValue: true },
+    { name: 'api_key', char: 'k', description: 'Override FASTLY_API_KEY config var', hasValue: true },
   ],
+
   run: hk.command(function(context, heroku) {
     return co(function* () {
+
       let baseUri = context.flags.api_uri || 'https://api.fastly.com'
+      let subscriptionUri = `${baseUri}/tls/subscriptions`
+
       let config = yield heroku.get(`/apps/${context.app}/config-vars`)
       let apiKey = context.flags.api_key || config.FASTLY_API_KEY
 
-      if (!apiKey) {
-        hk.error(
-          'config var FASTLY_API_KEY not found! The Fastly add-on is required to configure TLS. Install Fastly at https://elements.heroku.com/addons/fastly',
-        )
-        process.exit(1)
-      }
+      validateAPIKey(apiKey)
 
       if (context.flags.delete) {
 
-        const form = {
-          domain: context.args.domain,
-          service_id: config.FASTLY_SERVICE_ID, // eslint-disable-line camelcase
-        }
 
-        request(
-          {
-            method: 'DELETE',
-            url: `${baseUri}/plugin/heroku/tls`,
-            headers: { 'Fastly-Key': apiKey, 'Content-Type': 'application/json' },
-            form,
-          },
-          function(err, response, body) {
-            if (response.statusCode != 200) {
-              hk.error(
-                `Fastly API request Error! code: ${response.statusCode} ${response.statusMessage} ${
-                  JSON.parse(body).msg
-                }`,
-              )
-              process.exit(1)
-            } else {
-              hk.styledHeader(
-                `Domain ${
-                  context.args.domain
-                } queued for TLS removal. This domain will no longer support TLS`,
-              )
-            }
-          },
-        )
+        let tlsSubscriptionId = config.FASTLY_TLS_SUBSCRIPTION_ID
+        validateTlsSubscriptionId(tlsSubscriptionId)
+
+        deleteFastlyTlsSubscription(apiKey, subscriptionUri, tlsSubscriptionId, function(error, response, body) {
+          if (response.statusCode != 200) {
+
+            handleErrors(response, body)
+
+          } else {
+
+            heroku.patch(`/apps/${context.app}/config-vars`, {body: {FASTLY_TLS_SUBSCRIPTION_ID: null}}).then(app => {
+              hk.styledHeader(`Domain ${context.args.domain} TLS removed. This domain will no longer support TLS`)
+            })
+
+          }
+        })
 
       } else {
 
-        const form = {
-          domain: context.args.domain,
-          verification_type: 'dns', // eslint-disable-line camelcase
-          service_id: config.FASTLY_SERVICE_ID, // eslint-disable-line camelcase
-        }
+        createFastlyTlsSubscription(apiKey, subscriptionUri, context.args.domain, function(error, response, body) {
+          if (response.statusCode != 200) {
 
-        request(
-          {
-            method: 'POST',
-            url: `${baseUri}/plugin/heroku/tls`,
-            headers: { 'Fastly-Key': apiKey, 'Content-Type': 'application/json' },
-            form,
-          },
-          function(err, response, body) {
-            if (response.statusCode != 200) {
-              hk.error(
-                `Fastly API request Error! code: ${response.statusCode} ${response.statusMessage} ${
-                  JSON.parse(body).msg
-                }`,
-              )
-              process.exit(1)
-            } else {
-              const output = JSON.parse(body)
-              if (Array.isArray(output.msg)) {
-                output.msg.forEach(message => {
-                  if (!message.success) {
-                    if (Array.isArray(message.errors)) {
-                      message.errors.forEach(error => hk.error(error))
-                    }
-                  }
-                })
-              }
-              if (output.metatag) {
-                hk.styledHeader(
-                  `Domain ${
-                    context.args.domain
-                  } has been queued for TLS certificate addition. This may take a few minutes.`,
-                )
-                hk.warn(
-                  'In the mean time, start the domain verification process by creating a DNS TXT record containing the following content: \n',
-                )
-                hk.warn(output.metatag)
-                hk.warn(
-                  'Once you have added this TXT record you can start the verification process by running:\n',
-                )
-                hk.warn('$ heroku fastly:verify start DOMAIN —app APP')
-              } else {
-                hk.warn(
-                  'Unable to process this request. Please wait a few minutes and try your request again. If the problem persists, please contact support@fastly.com ❤️',
-                )
-              }
-            }
-          },
-        )
+            handleErrors(response, body)
+
+          } else {
+
+            hk.styledHeader(`Domain ${context.args.domain} TLS created. This domain will no longer support TLS`)
+          }
+          console.log(response.body)
+        })
 
       }
     })
   }),
+}
+
+function validateAPIKey(apiKey) {
+
+  if (!apiKey) {
+    hk.error('config var FASTLY_API_KEY not found! The Fastly add-on is required to configure TLS. Install Fastly at https://elements.heroku.com/addons/fastly')
+    process.exit(1)
+  }
+}
+
+function validateTlsSubscriptionId(tlsSubscriptionId) {
+
+  if (!tlsSubscriptionId) {
+    hk.error('config var FASTLY_TLS_SUBSCRIPTION_ID not found! An existing TLS Subscription must be present to delete it.')
+    process.exit(1)
+  }
+}
+
+function handleErrors(response, body) {
+
+  let errors = JSON.parse(body).errors
+  let errorMessage = `Fastly API request Error - code: ${response.statusCode} ${response.statusMessage}\n`
+
+  for (var i = 0; i < errors.length; i++) {
+    errorMessage += `${errors[i].title} - ${errors[i].detail}\n`
+  }
+
+  hk.error(errorMessage.trim())
+  process.exit(1)
+}
+
+function createFastlyTlsSubscription(apiKey, subscriptionUri, domain, callback) {
+
+  request(
+    subscriptionUri,
+    {
+      method: 'POST',
+      'headers': {
+        'Accept': 'application/vnd.api+json',
+        'Content-Type': ['application/vnd.api+json'],
+        'Fastly-Key': apiKey,
+      },
+      'body': JSON.stringify({
+        data: {
+          type: "tls_subscription",
+          attributes: {
+            certificate_authority: "lets-encrypt"
+          },
+          relationships: {
+            tls_domains: {
+              data: [
+                { type: "tls_domain", id: domain }
+              ]
+            },
+            tls_configuration: {
+              data: {}
+            }
+          }
+        }
+      }),
+    },
+    callback)
+}
+
+function deleteFastlyTlsSubscription(apiKey, subscriptionUri, tlsSubscriptionId, callback) {
+
+  request(
+    `${subscriptionUri}/${tlsSubscriptionId}`,
+    {
+      method: 'DELETE',
+      'headers': {
+        'Accept': 'application/vnd.api+json',
+        'Content-Type': ['application/vnd.api+json'],
+        'Fastly-Key': apiKey,
+      },
+    },
+    callback)
 }

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -17,7 +17,7 @@ You must verify ownership of DOMAIN after running this command. \n\
 Valid VERIFICATION_TYPES: dns\n\
   DNS: Create a DNS TXT record with the provided metatag via your DNS provider. \n\
 Usage: \n\
-  heroku fastly:tls www.example.org dns --app my-fast-app\n ',
+  heroku fastly:tls www.example.org --app my-fast-app\n ',
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'domain', description: 'The domain for TLS configure' }],
@@ -45,15 +45,18 @@ Usage: \n\
       }
 
       if (context.flags.delete) {
+
+        const form = {
+          domain: context.args.domain,
+          service_id: config.FASTLY_SERVICE_ID, // eslint-disable-line camelcase
+        }
+
         request(
           {
             method: 'DELETE',
             url: `${baseUri}/plugin/heroku/tls`,
             headers: { 'Fastly-Key': apiKey, 'Content-Type': 'application/json' },
-            form: {
-              domain: context.args.domain,
-              service_id: config.FASTLY_SERVICE_ID, // eslint-disable-line camelcase
-            },
+            form,
           },
           function(err, response, body) {
             if (response.statusCode != 200) {
@@ -72,12 +75,15 @@ Usage: \n\
             }
           }
         )
+
       } else {
+
         const form = {
           domain: context.args.domain,
           verification_type: 'dns', // eslint-disable-line camelcase
           service_id: config.FASTLY_SERVICE_ID, // eslint-disable-line camelcase
         }
+
         request(
           {
             method: 'POST',
@@ -126,6 +132,7 @@ Usage: \n\
             }
           }
         )
+
       }
     })
   }),

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -129,7 +129,7 @@ function deleteFastlyTlsSubscription(apiKey, baseUri, domain) {
       let tlsSubscriptionId = jp.query(domainData, `$.data[?(@.id == \'${domain}\')].relationships.tls_subscriptions.data[0].id`);
 
       // 2. Delete the activations against the domain.
-      if(!tlsActivationId) {
+      if(tlsActivationId) {
         options.method = 'DELETE';
         const activationResponse = await fetch(`${baseUri}/tls/activations/${tlsActivationId}`, options);
 
@@ -142,7 +142,7 @@ function deleteFastlyTlsSubscription(apiKey, baseUri, domain) {
       }
 
       // 3. Delete the subscription against the domain.
-      if(!tlsSubscriptionId) {
+      if(tlsSubscriptionId) {
         options.method = 'DELETE';
         const response = await fetch(`${baseUri}/tls/subscriptions/${tlsSubscriptionId}`, options);
 

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -2,7 +2,7 @@
 const hk = require('heroku-cli-util')
 const fetch = require('node-fetch');
 const co = require('co')
-var jp = require('jsonpath');
+const jp = require('jsonpath');
 
 module.exports = {
 

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -7,17 +7,7 @@ module.exports = {
   topic: 'fastly',
   command: 'tls',
   description: 'Add/Remove Fastly TLS to DOMAIN',
-  help:
-    'DOMAIN will be added to a Fastly Heroku SAN SSL certificate. \n\n\
-Requirements: \n\
- - The Fastly Service must have DOMAIN configured in the active version \n\
- - Heroku pricing plan must include TLS Domain(s) \n\
- - Wildcard domains are not allowed \n\n\
-You must verify ownership of DOMAIN after running this command. \n\
-Valid VERIFICATION_TYPES: dns\n\
-  DNS: Create a DNS TXT record with the provided metatag via your DNS provider. \n\
-Usage: \n\
-  heroku fastly:tls www.example.org --app my-fast-app\n ',
+  help: 'TODO - Update documentation to reflect the use of tls/subscriptions',
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'domain', description: 'The domain for TLS configure' }],

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -32,14 +32,14 @@ Usage: \n\
     { name: 'api_uri', char: 'u', description: 'Override Fastly API URI', hasValue: true },
   ],
   run: hk.command(function(context, heroku) {
-    return co(function*() {
+    return co(function* () {
       let baseUri = context.flags.api_uri || 'https://api.fastly.com'
       let config = yield heroku.get(`/apps/${context.app}/config-vars`)
       let apiKey = context.flags.api_key || config.FASTLY_API_KEY
 
       if (!apiKey) {
         hk.error(
-          'config var FASTLY_API_KEY not found! The Fastly add-on is required to configure TLS. Install Fastly at https://elements.heroku.com/addons/fastly'
+          'config var FASTLY_API_KEY not found! The Fastly add-on is required to configure TLS. Install Fastly at https://elements.heroku.com/addons/fastly',
         )
         process.exit(1)
       }
@@ -63,17 +63,17 @@ Usage: \n\
               hk.error(
                 `Fastly API request Error! code: ${response.statusCode} ${response.statusMessage} ${
                   JSON.parse(body).msg
-                }`
+                }`,
               )
               process.exit(1)
             } else {
               hk.styledHeader(
                 `Domain ${
                   context.args.domain
-                } queued for TLS removal. This domain will no longer support TLS`
+                } queued for TLS removal. This domain will no longer support TLS`,
               )
             }
-          }
+          },
         )
 
       } else {
@@ -96,7 +96,7 @@ Usage: \n\
               hk.error(
                 `Fastly API request Error! code: ${response.statusCode} ${response.statusMessage} ${
                   JSON.parse(body).msg
-                }`
+                }`,
               )
               process.exit(1)
             } else {
@@ -114,23 +114,23 @@ Usage: \n\
                 hk.styledHeader(
                   `Domain ${
                     context.args.domain
-                  } has been queued for TLS certificate addition. This may take a few minutes.`
+                  } has been queued for TLS certificate addition. This may take a few minutes.`,
                 )
                 hk.warn(
-                  'In the mean time, start the domain verification process by creating a DNS TXT record containing the following content: \n'
+                  'In the mean time, start the domain verification process by creating a DNS TXT record containing the following content: \n',
                 )
                 hk.warn(output.metatag)
                 hk.warn(
-                  'Once you have added this TXT record you can start the verification process by running:\n'
+                  'Once you have added this TXT record you can start the verification process by running:\n',
                 )
                 hk.warn('$ heroku fastly:verify start DOMAIN —app APP')
               } else {
                 hk.warn(
-                  'Unable to process this request. Please wait a few minutes and try your request again. If the problem persists, please contact support@fastly.com ❤️'
+                  'Unable to process this request. Please wait a few minutes and try your request again. If the problem persists, please contact support@fastly.com ❤️',
                 )
               }
             }
-          }
+          },
         )
 
       }

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -95,7 +95,7 @@ function processVerifyResponse(data, domain) {
 
   hk.styledHeader(`Domain ${domain} TLS subscription state: ${status}`);
 
-  if(status == 'issued'){
+  if(status === 'issued'){
     hk.log(`Domain ${domain} now supports TLS.`);
   } else {
     hk.log(`The issuing of a certificate may take up to 30 minutes.  In the mean time please confirm your DNS records are configured with your DNS provider for ${domain}`);

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -95,8 +95,8 @@ function processVerifyResponse(data, domain) {
 
   hk.styledHeader(`Domain ${domain} TLS subscription state: ${status}`);
 
-  if(status === 'issued'){
-    hk.log(`Domain ${domain} now supports TLS.`);
+  if(status === 'issued' || status === 'renewing'){
+    hk.log(`Domain ${domain} supporting TLS.`);
   } else {
     hk.log(`The issuing of a certificate may take up to 30 minutes.  In the mean time please confirm your DNS records are configured with your DNS provider for ${domain}`);
   }

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -7,28 +7,16 @@ const jp = require('jsonpath');
 module.exports = {
   topic: 'fastly',
   command: 'verify',
-  description: 'check on the status of the Fastly TLS subscription',
-  help:
-    'This validates the metatag you set as a DNS TXT record or as metatag in the html of your root page.',
+  description: 'Check the status of the Fastly TLS subscription.',
+  help: 'A command that allows the status of the Fastly TLS subscription to be checked.',
   needsApp: true,
   needsAuth: true,
   args: [
-    {
-      name: 'verification_action',
-      description:
-        'Start the verification process, check on its status, or confirm its completion.',
-      optional: false,
-    },
-    { name: 'domain', description: 'The domain to verify', optional: false },
+    { name: 'domain', description: 'The domain to check', optional: false },
   ],
   flags: [
-    {
-      name: 'api_key',
-      char: 'k',
-      description: 'Override Fastly_API_KEY config var',
-      hasValue: true,
-    },
     { name: 'api_uri', char: 'u', description: 'Override Fastly API URI', hasValue: true },
+    { name: 'api_key', char: 'k', description: 'Override Fastly_API_KEY config var', hasValue: true },
   ],
   run: hk.command(function(context, heroku) {
     return co(function*() {
@@ -41,8 +29,6 @@ module.exports = {
       validateAPIKey(apiKey);
 
       verifyFastlyTlsSubscription(apiKey, baseUri, domain);
-
-
     })
   }),
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -487,8 +487,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "del": {
       "version": "2.2.2",
@@ -543,6 +542,18 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
     },
     "eslint": {
       "version": "4.19.1",
@@ -670,14 +681,12 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "execa": {
       "version": "0.10.0",
@@ -747,8 +756,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastly": {
       "version": "2.2.1",
@@ -1305,6 +1313,23 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "jsonpath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.2.tgz",
+      "integrity": "sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==",
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.7.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -1335,7 +1360,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -1476,6 +1500,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "normalize-url": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
@@ -1534,7 +1563,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -1631,8 +1659,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -1924,6 +1951,12 @@
         "is-plain-obj": "^1.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1951,6 +1984,14 @@
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
+      }
+    },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "requires": {
+        "escodegen": "^1.8.1"
       }
     },
     "strict-uri-encode": {
@@ -2079,7 +2120,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -2095,6 +2135,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
     },
     "url-parse-lax": {
       "version": "3.0.0",
@@ -2147,8 +2192,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "co": "^4.6.0",
     "fastly": "^2.2.1",
     "heroku-cli-util": "^8.0.10",
+    "jsonpath": "^1.0.2",
+    "node-fetch": "^2.6.1",
     "request": "^2.69.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -11,4 +11,8 @@ describe('fastly', function () {
     index.commands[1].command.should.equal('tls');
   });
 
+  it('has a verify command', function () {
+    index.commands[2].command.should.equal('verify');
+  });
+
 });


### PR DESCRIPTION
This PR covers the re-implementation of the tls and verify commands on the fastly heroku plugin to use the fastly tls endpoints.  The main endpoint being used is the `tls/subsctiptions` followed by `tls/activations` and `tls/domains` to add and then deleted TLS Certification subscriptions/activations.

The tls create command will output details to be used in the DNS records.  Currently this is the only time these values are shown.  The tls verify command focuses on the communication of the subscription state.
