### PR TITLE
Expand tests covering api and utils modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4283,6 +4283,12 @@
         "@types/node": "*"
       }
     },
+    "jest-mock-process": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jest-mock-process/-/jest-mock-process-1.4.0.tgz",
+      "integrity": "sha512-3LM1TyEaRKRjh/x9rZPmuy28r7q8cgNkHYcrPWtxXT3ZzPPS+bKNs2ysb8BJPVB41X5yM1sMtatvE5z2XJ0S/w==",
+      "dev": true
+    },
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint": "^7.9.0",
     "jest": "^26.4.2",
     "jest-fetch-mock": "^3.0.3",
+    "jest-mock-process": "^1.4.0",
     "prettier": "^2.1.2",
     "request": "^2.88.2"
   },

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 require('jest-fetch-mock').enableMocks()
-const apiClient = require('./api')
+const apiClient = require('../commands/api')
 
 describe('interaction with fastly api', () => {
   beforeEach(() => {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -50,4 +50,84 @@ describe('interaction with fastly api', () => {
       }
     )
   })
+
+  it('calls fastly get domains with correct url and headers', async () => {
+    fetch.mockResponses(JSON.stringify({ data: {} }), { status: 200 })
+
+    let expectedFastlyApiKey = 'XXXXXXXXX'
+
+    let api = new apiClient({
+      apiKey: `${expectedFastlyApiKey}`,
+    })
+
+    let json = await api.getDomains()
+
+    expect(json).not.toBeNull()
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.fastly.com/tls/domains?include=tls_activations,tls_subscriptions.tls_authorizations,tls_subscriptions',
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json',
+          'Fastly-Key': `${expectedFastlyApiKey}`,
+        },
+      }
+    )
+  })
+
+  it('calls fastly delete activation with correct url and headers', async () => {
+    fetch.mockResponses(JSON.stringify({ data: {} }), { status: 204 })
+
+    let expectedFastlyApiKey = 'XXXXXXXXX'
+    let expectedFastlyActivationId = 'xnXOIZM4ebbmSA5dgk3xmw'
+
+    let api = new apiClient({
+      apiKey: `${expectedFastlyApiKey}`,
+    })
+
+    let json = await api.deleteActivation(expectedFastlyActivationId)
+
+    expect(json).not.toBeNull()
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith(
+      `https://api.fastly.com/tls/activations/${expectedFastlyActivationId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json',
+          'Fastly-Key': `${expectedFastlyApiKey}`,
+        },
+      }
+    )
+  })
+
+  it('calls fastly delete subscription with correct url and headers', async () => {
+    fetch.mockResponses(JSON.stringify({ data: {} }), { status: 204 })
+
+    let expectedFastlyApiKey = 'XXXXXXXXX'
+    let expectedFastlySubscriptionId = 'DzZk7Txr2XJmDDqYSOSA0A'
+
+    let api = new apiClient({
+      apiKey: `${expectedFastlyApiKey}`,
+    })
+
+    let json = await api.deleteSubscription(expectedFastlySubscriptionId)
+
+    expect(json).not.toBeNull()
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith(
+      `https://api.fastly.com/tls/subscriptions/${expectedFastlySubscriptionId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json',
+          'Fastly-Key': `${expectedFastlyApiKey}`,
+        },
+      }
+    )
+  })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -112,4 +112,16 @@ describe('interaction with utils functions', () => {
     expect(herokuErrorSpy).not.toBeCalled()
     expect(mockExit).not.toBeCalled()
   })
+
+  it('renders error as expected', async () => {
+    const errFunc = utils.renderFastlyError()
+
+    errFunc({ name: 'test error', message: 'test error message' })
+
+    expect(herokuErrorSpy).toBeCalledTimes(1)
+    expect(herokuErrorSpy).toBeCalledWith(
+      'Fastly Plugin execution error - test error - test error message'
+    )
+    expect(mockExit).toBeCalledTimes(1)
+  })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,10 +5,14 @@ const hk = require('heroku-cli-util')
 var mockProcess = require('jest-mock-process')
 
 describe('interaction with utils functions', () => {
-  const consoleSpy = jest.spyOn(console, 'log')
+  const herokuErrorSpy = jest.spyOn(hk, 'error')
+  const mockExit = mockProcess.mockProcessExit()
+  const mockLog = mockProcess.mockConsoleLog()
 
   beforeEach(() => {
-    consoleSpy.mockReset()
+    mockLog.mockReset()
+    herokuErrorSpy.mockReset()
+    mockExit.mockReset()
   })
 
   const testChallenges = [
@@ -40,12 +44,12 @@ describe('interaction with utils functions', () => {
   it('confirm managed-dns challenge renders correctly', async () => {
     utils.displayChallenge(testChallenges, 'managed-dns')
 
-    expect(consoleSpy).toHaveBeenCalledTimes(3)
-    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Type: CNAME')
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(mockLog).toHaveBeenCalledTimes(3)
+    expect(mockLog).toHaveBeenCalledWith('DNS Record Type: CNAME')
+    expect(mockLog).toHaveBeenCalledWith(
       'DNS Record Name: _acme-challenge.www.example.org'
     )
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(mockLog).toHaveBeenCalledWith(
       'DNS Record value(s): dvxzuc4govtr3juagj.fastly-validations.com\n'
     )
   })
@@ -53,10 +57,10 @@ describe('interaction with utils functions', () => {
   it('confirm managed-http-cname challenge renders correctly', async () => {
     utils.displayChallenge(testChallenges, 'managed-http-cname')
 
-    expect(consoleSpy).toHaveBeenCalledTimes(3)
-    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Type: CNAME')
-    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Name: www.example.org')
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(mockLog).toHaveBeenCalledTimes(3)
+    expect(mockLog).toHaveBeenCalledWith('DNS Record Type: CNAME')
+    expect(mockLog).toHaveBeenCalledWith('DNS Record Name: www.example.org')
+    expect(mockLog).toHaveBeenCalledWith(
       'DNS Record value(s): j.sni.global.fastly.net\n'
     )
   })
@@ -64,10 +68,10 @@ describe('interaction with utils functions', () => {
   it('confirm managed-http-a challenge renders correctly', async () => {
     utils.displayChallenge(testChallenges, 'managed-http-a')
 
-    expect(consoleSpy).toHaveBeenCalledTimes(3)
-    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Type: A')
-    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Name: www.example.org')
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(mockLog).toHaveBeenCalledTimes(3)
+    expect(mockLog).toHaveBeenCalledWith('DNS Record Type: A')
+    expect(mockLog).toHaveBeenCalledWith('DNS Record Name: www.example.org')
+    expect(mockLog).toHaveBeenCalledWith(
       'DNS Record value(s): 151.101.2.132, 151.101.66.132, 151.101.130.132, 151.101.194.132\n'
     )
   })
@@ -84,19 +88,15 @@ describe('interaction with utils functions', () => {
 
     utils.displayChallenge(challenges, 'managed-http-a')
 
-    expect(consoleSpy).toHaveBeenCalledTimes(3)
-    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Type: A')
-    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Name: www.example.org')
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(mockLog).toHaveBeenCalledTimes(3)
+    expect(mockLog).toHaveBeenCalledWith('DNS Record Type: A')
+    expect(mockLog).toHaveBeenCalledWith('DNS Record Name: www.example.org')
+    expect(mockLog).toHaveBeenCalledWith(
       'DNS Record value(s): 151.101.2.132, 151.101.66.132\n'
     )
   })
 
   it('renders error message and exits when no API key is supplied', async () => {
-    const mockExit = mockProcess.mockProcessExit()
-    const herokuErrorSpy = jest.spyOn(hk, 'error')
-    herokuErrorSpy.mockReset()
-
     utils.validateAPIKey(null)
 
     expect(herokuErrorSpy).toHaveBeenCalledTimes(1)
@@ -107,10 +107,6 @@ describe('interaction with utils functions', () => {
   })
 
   it('does not render error or exits when a API key is supplied', async () => {
-    const mockExit = mockProcess.mockProcessExit()
-    const herokuErrorSpy = jest.spyOn(hk, 'error')
-    herokuErrorSpy.mockReset()
-
     utils.validateAPIKey('XXXXXXXXX')
 
     expect(herokuErrorSpy).not.toBeCalled()

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const utils = require('../commands/utils')
+const hk = require('heroku-cli-util')
+var mockProcess = require('jest-mock-process')
 
 describe('interaction with utils functions', () => {
   const consoleSpy = jest.spyOn(console, 'log')
@@ -88,5 +90,30 @@ describe('interaction with utils functions', () => {
     expect(consoleSpy).toHaveBeenCalledWith(
       'DNS Record value(s): 151.101.2.132, 151.101.66.132\n'
     )
+  })
+
+  it('renders error message and exits when no API key is supplied', async () => {
+    const mockExit = mockProcess.mockProcessExit()
+    const herokuErrorSpy = jest.spyOn(hk, 'error')
+    herokuErrorSpy.mockReset()
+
+    utils.validateAPIKey(null)
+
+    expect(herokuErrorSpy).toHaveBeenCalledTimes(1)
+    expect(herokuErrorSpy).toHaveBeenCalledWith(
+      'config var FASTLY_API_KEY not found! The Fastly add-on is required to configure TLS. Install Fastly at https://elements.heroku.com/addons/fastly'
+    )
+    expect(mockExit).toBeCalledWith(1)
+  })
+
+  it('does not render error or exits when a API key is supplied', async () => {
+    const mockExit = mockProcess.mockProcessExit()
+    const herokuErrorSpy = jest.spyOn(hk, 'error')
+    herokuErrorSpy.mockReset()
+
+    utils.validateAPIKey('XXXXXXXXX')
+
+    expect(herokuErrorSpy).not.toBeCalled()
+    expect(mockExit).not.toBeCalled()
   })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,92 @@
+'use strict'
+
+const utils = require('../commands/utils')
+
+describe('interaction with utils functions', () => {
+  const consoleSpy = jest.spyOn(console, 'log')
+
+  beforeEach(() => {
+    consoleSpy.mockReset()
+  })
+
+  const testChallenges = [
+    {
+      type: 'managed-dns',
+      record_type: 'CNAME',
+      record_name: '_acme-challenge.www.example.org',
+      values: ['dvxzuc4govtr3juagj.fastly-validations.com'],
+    },
+    {
+      type: 'managed-http-cname',
+      record_type: 'CNAME',
+      record_name: 'www.example.org',
+      values: ['j.sni.global.fastly.net'],
+    },
+    {
+      type: 'managed-http-a',
+      record_type: 'A',
+      record_name: 'www.example.org',
+      values: [
+        '151.101.2.132',
+        '151.101.66.132',
+        '151.101.130.132',
+        '151.101.194.132',
+      ],
+    },
+  ]
+
+  it('confirm managed-dns challenge renders correctly', async () => {
+    utils.displayChallenge(testChallenges, 'managed-dns')
+
+    expect(consoleSpy).toHaveBeenCalledTimes(3)
+    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Type: CNAME')
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'DNS Record Name: _acme-challenge.www.example.org'
+    )
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'DNS Record value(s): dvxzuc4govtr3juagj.fastly-validations.com\n'
+    )
+  })
+
+  it('confirm managed-http-cname challenge renders correctly', async () => {
+    utils.displayChallenge(testChallenges, 'managed-http-cname')
+
+    expect(consoleSpy).toHaveBeenCalledTimes(3)
+    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Type: CNAME')
+    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Name: www.example.org')
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'DNS Record value(s): j.sni.global.fastly.net\n'
+    )
+  })
+
+  it('confirm managed-http-a challenge renders correctly', async () => {
+    utils.displayChallenge(testChallenges, 'managed-http-a')
+
+    expect(consoleSpy).toHaveBeenCalledTimes(3)
+    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Type: A')
+    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Name: www.example.org')
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'DNS Record value(s): 151.101.2.132, 151.101.66.132, 151.101.130.132, 151.101.194.132\n'
+    )
+  })
+
+  it('confirm managed-http-a challenge renders correctly with fewer ip addresses', async () => {
+    const challenges = [
+      {
+        type: 'managed-http-a',
+        record_type: 'A',
+        record_name: 'www.example.org',
+        values: ['151.101.2.132', '151.101.66.132'],
+      },
+    ]
+
+    utils.displayChallenge(challenges, 'managed-http-a')
+
+    expect(consoleSpy).toHaveBeenCalledTimes(3)
+    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Type: A')
+    expect(consoleSpy).toHaveBeenCalledWith('DNS Record Name: www.example.org')
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'DNS Record value(s): 151.101.2.132, 151.101.66.132\n'
+    )
+  })
+})


### PR DESCRIPTION
The unit tests have been expanded to cover the api and utils modules.  All tests have been moved to the test directory under root.